### PR TITLE
Fix a case where the image_count in `SwapchainProperties` and `Swapchain.image_count()` are different

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -129,7 +129,7 @@ impl Renderer {
         let in_flight_frames = create_sync_objects(&context);
 
         let camera_uniform_buffers =
-            create_camera_uniform_buffers(&context, swapchain_properties.image_count);
+            create_camera_uniform_buffers(&context, swapchain.image_count() as u32);
 
         let light_render_pass = LightRenderPass::create(
             Arc::clone(&context),
@@ -564,7 +564,7 @@ impl Renderer {
         let model_data = ModelData::create(
             Arc::clone(&self.context),
             Rc::downgrade(model),
-            swapchain_properties,
+            self.swapchain.image_count() as u32,
         );
 
         let gbuffer_pass = GBufferPass::create(

--- a/src/renderer/model/mod.rs
+++ b/src/renderer/model/mod.rs
@@ -12,7 +12,7 @@ use std::cell::RefCell;
 use std::rc::Weak;
 use std::sync::Arc;
 use uniform::*;
-use vulkan::{mem_copy, mem_copy_aligned, Buffer, Context, SwapchainProperties};
+use vulkan::{mem_copy, mem_copy_aligned, Buffer, Context};
 
 type JointsBuffer = [Matrix4<f32>; MAX_JOINTS_PER_MESH];
 
@@ -36,18 +36,18 @@ impl ModelData {
         context: Arc<Context>,
 
         model: Weak<RefCell<Model>>,
-        swapchain_props: SwapchainProperties,
+        image_count: u32,
     ) -> Self {
         let model_rc = model
             .upgrade()
             .expect("Cannot create model renderer because model was dropped");
 
         let transform_ubos =
-            create_transform_ubos(&context, &model_rc.borrow(), swapchain_props.image_count);
+            create_transform_ubos(&context, &model_rc.borrow(), image_count);
         let (skin_ubos, skin_matrices) =
-            create_skin_ubos(&context, &model_rc.borrow(), swapchain_props.image_count);
+            create_skin_ubos(&context, &model_rc.borrow(), image_count);
         let light_buffers =
-            create_lights_ubos(&context, &model_rc.borrow(), swapchain_props.image_count);
+            create_lights_ubos(&context, &model_rc.borrow(), image_count);
 
         Self {
             context,


### PR DESCRIPTION
Hi! When I tried this out I got a panic:
```
thread 'main' panicked at 'range end index 5 out of range for slice of length 4', src/renderer/ssao/mod.rs:301:18
stack backtrace:
   0: rust_begin_unwind
             at /rustc/ffa2e7ae8fbf9badc035740db949b9dae271c29f/library/std/src/panicking.rs:483:5
   1: core::panicking::panic_fmt
             at /rustc/ffa2e7ae8fbf9badc035740db949b9dae271c29f/library/core/src/panicking.rs:85:14
   2: core::slice::index::slice_end_index_len_fail
             at /rustc/ffa2e7ae8fbf9badc035740db949b9dae271c29f/library/core/src/slice/index.rs:41:5
   3: <core::ops::range::Range<usize> as core::slice::index::SliceIndex<[T]>>::index
             at /home/ashley/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:238:13
   4: <core::ops::range::RangeInclusive<usize> as core::slice::index::SliceIndex<[T]>>::index
             at /home/ashley/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:404:9
   5: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /home/ashley/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:15:9
   6: <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index
             at /home/ashley/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec.rs:1939:9
   7: gltf_viewer_rs::renderer::ssao::SSAOPass::cmd_draw
             at ./src/renderer/ssao/mod.rs:301:18
   8: gltf_viewer_rs::renderer::Renderer::cmd_draw
             at ./src/renderer/mod.rs:468:13
   9: gltf_viewer_rs::renderer::Renderer::render
             at ./src/renderer/mod.rs:353:13
  10: gltf_viewer_rs::run::{{closure}}
             at ./src/main.rs:167:21
  11: winit::platform_impl::platform::sticky_exit_callback
             at /home/ashley/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.22.2/src/platform_impl/linux/mod.rs:698:5
  12: winit::platform_impl::platform::x11::EventLoop<T>::run_return
             at /home/ashley/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.22.2/src/platform_impl/linux/x11/mod.rs:299:17
  13: winit::platform_impl::platform::x11::EventLoop<T>::run
             at /home/ashley/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.22.2/src/platform_impl/linux/x11/mod.rs:390:9
  14: winit::platform_impl::platform::EventLoop<T>::run
             at /home/ashley/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.22.2/src/platform_impl/linux/mod.rs:645:35
  15: winit::event_loop::EventLoop<T>::run
             at /home/ashley/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.22.2/src/event_loop.rs:149:9
  16: gltf_viewer_rs::run
             at ./src/main.rs:82:5
  17: gltf_viewer_rs::main
             at ./src/main.rs:36:5
  18: core::ops::function::FnOnce::call_once
             at /home/ashley/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
The line in question is this one:
```
&self.descriptors.per_frame_sets[frame_index..=frame_index],
```

I did some digging and found that the length of `per_frame_sets` is set to the length of `camera_buffers`, the length of which is in turn set to the `swapchain_properties.image_count`.

On my machine for whatever reason `swapchain_properties.image_count` is `4`, which `swapchain.image_count()` is `5`.

This PR changes it so that only `swapchain.image_count()` is used, and not `swapchain_properties.image_count`. This fixes the panics for me and I can actually use the viewer now :D ! Feel free to close if you feel that another solution would work better though.